### PR TITLE
Cache deps

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,10 +10,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with: {python-version: 3.8}
-      - uses: actions/cache@v2
+      - id: cachevenv
+        uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key:          ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
-      - run: pip install -r requirements.txt
-      - run: pytest -v
+          path: venv
+          key:          ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-venv-
+      - run: python -m venv venv
+        if: !steps.cachevenv.outputs.cache-hit
+      - run: venv/bin/pip install -r requirements.txt
+        if: !steps.cachevenv.outputs.cache-hit
+      - run: venv/bin/pytest -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,5 +10,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with: {python-version: 3.8}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key:          ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
       - run: pip install -r requirements.txt
       - run: pytest -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
           key:          ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt') }}
           restore-keys: ${{ runner.os }}-venv-
       - run: python -m venv venv
-        if: !steps.cachevenv.outputs.cache-hit
+        if: ! steps.cachevenv.outputs.cache-hit
       - run: venv/bin/pip install -r requirements.txt
-        if: !steps.cachevenv.outputs.cache-hit
+        if: ! steps.cachevenv.outputs.cache-hit
       - run: venv/bin/pytest -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
           key:          ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt') }}
           restore-keys: ${{ runner.os }}-venv-
       - run: python -m venv venv
-        if: ! steps.cachevenv.outputs.cache-hit
+        if: '!steps.cachevenv.outputs.cache-hit'
       - run: venv/bin/pip install -r requirements.txt
-        if: ! steps.cachevenv.outputs.cache-hit
+        if: '!steps.cachevenv.outputs.cache-hit'
       - run: venv/bin/pytest -v


### PR DESCRIPTION
the python example for github actions still runs `pip install` even if it's a cache hit, but pip itself is realllly slow, so it only saved a couple seconds on >1.5minutes.

so, now it installs deps to a virutalenv, and caches/restores that, skipping all the install stuff on cache hit. it takes ~8s now.