### PR TITLE
Preview and save markdown rerenders

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -71,6 +71,17 @@ button.sad:hover,
   background: #846;
   color: #fff;
 }
+button.ooo,
+.button.ooo {
+  color: #486;
+  background: transparent;
+  border: 1px dotted #486;
+}
+button.ooo:hover,
+.button.ooo:hover {
+  background: #486;
+  color: #fff;
+}
 button,
 a.button {
   background: #468;
@@ -126,6 +137,8 @@ code {
   border-width: 0;
   border-radius: 0;
   color: inherit;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .notice {
@@ -187,4 +200,15 @@ code {
   padding: 0;
   position: absolute;
   width: 1px;
+}
+
+.rerender-preview-compare {
+  display: flex;
+  justify-content: space-between;
+}
+.rerender-preview-compare > div {
+  flex: 0 1 48%;
+}
+.rerender-title {
+  margin: 0.667em 0 1.333em;
 }

--- a/templates/blog-list.html
+++ b/templates/blog-list.html
@@ -23,10 +23,13 @@
           {{ post.datetime | nice_date }}
         </time>
         {% if current_user.is_blogger(blogger) %}
-          <form class="inline" method="post" action="{{ url_for('account.remove_post', blogger=blogger.username, repo_name=post.repo.full_name, hex=post.hex) }}">
+          <form class="inline" method="post" action="{{ url_for('account.remove_post', repo_name=post.repo.full_name, hex=post.hex) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             <button type="submit" class="sad">Unpost</button>
           </form>
+          {% if post.can_rerender() %}
+            <a href="{{ url_for('account.rerender_preview', repo_name=post.repo.full_name, hex=post.hex) }}" class="button ooo" title="This post was rendered with a previous markdown configuration. If it has errors in its presentation, rerendering now might fix it.">rerender</a>
+          {% endif %}
         {% endif %}
       </header>
       <div class="post-body">

--- a/templates/blog-post.html
+++ b/templates/blog-post.html
@@ -14,6 +14,9 @@
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           <button type="submit" class="sad">Unpost</button>
         </form>
+        {% if post.can_rerender() %}
+          <a href="{{ url_for('account.rerender_preview', repo_name=post.repo.full_name, hex=post.hex) }}" class="button ooo" title="This post was rendered with a previous markdown configuration. If it has errors in its presentation, rerendering now might fix it.">rerender</a>
+        {% endif %}
       {% endif %}
     </header>
     <div class="post-body">

--- a/templates/rerender-preview.html
+++ b/templates/rerender-preview.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+
+{% block title %}$ --title "{{ post.get_title() }}"{% endblock %}
+
+{% block content %}
+  <article>
+    <header>
+      <h1>{{ post.get_title() }} <small>{{ post.repo.full_name }}</small></h1>
+      <time datetime="{{ post.datetime.isoformat() }}">
+        {{ post.datetime | nice_date }}
+      </time>
+    </header>
+    <div class="rerender-preview-compare">
+      <div class="post-body">
+        <h3 class="rerender-title"><em>Previous render</em></h3>
+        {{ post.get_body(markdown=True)|safe }}
+      </div>
+      <div class="post-body">
+        <h3 class="rerender-title"><em>New rerender</em></h3>
+        {{ preview|safe }}
+      </div>
+    </div>
+  </article>
+
+  <form method="post" action="{{ url_for('account.rerender_preview', repo_name=post.repo.full_name, hex=post.hex) }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <div class="rerender-preview-compare">
+      <div>
+        <a href="javascript:history.go(-1)" class="button sad">✗ Stick with this version</a>
+      </div>
+      <div>
+        <button type="submit" class="">✓ Accept new render</button>
+      </div>
+    </div>
+  </form>
+{% endblock %}


### PR DESCRIPTION
Since the config for markdown rendering is likely to change in the future, this
adds detection of posts that have been rendered with previous configurations,
with the option to preview a rerender under the new config.

If the new render result is identical, the rerender and version bump is auto-
committed. If it differs, a preview is shown where it can either be committed
or left as-is.

Contains hacks; :shrug: