### PR TITLE
Fix more markdown regressions

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -108,7 +108,7 @@ class CommitPost(db.Model):
         print('asdfasdf')
         if text := self.get_body():
             user, repo_name = self.repo.full_name.split('/', 1)
-            html = render_message.render_github(text, user, repo_name)
+            html = render_message.render_github(text, user, repo_name, self.hex)
             self.markdown_body = html
 
     def get_title(self):
@@ -116,22 +116,9 @@ class CommitPost(db.Model):
 
     def get_body(self, markdown=False):
         if markdown:
-            return self.fix_gh_img(self.markdown_body)
+            return self.markdown_body
         else:
             return message_parts(self.message)[1]
-
-    def fix_gh_img(self, html):
-        def repl(m):
-            path = m.groupdict()['path']
-            if '://' in path:
-                return m.group(0)
-            else:
-                fixed_path = '{base}/{repo}/{sha}/{path}'.format(
-                    base=GH_RAW_BASE, repo=self.repo.full_name, sha=self.hex,
-                    path=path)
-                return m.group(0).replace(path, fixed_path)
-
-        return re.sub(r'<img src="(?P<path>.*?)"', repl, html)
 
     def can_rerender(self):
         return self.markdown_renderer != render_message.__version__
@@ -139,7 +126,7 @@ class CommitPost(db.Model):
     def get_rerender_preview(self):
         if text := self.get_body():
             user, repo_name = self.repo.full_name.split('/', 1)
-            return render_message.render_github(text, user, repo_name)
+            return render_message.render_github(text, user, repo_name, self.hex)
 
     def apply_rerender(self):
         html = self.get_rerender_preview()

--- a/render_message.py
+++ b/render_message.py
@@ -1,33 +1,75 @@
 import bleach
 import markdown
-from bleach_whitelist import markdown_tags, markdown_attrs
+from bleach_allowlist import markdown_tags
 from collections import defaultdict
+from functools import partial
+from markdown.extensions import Extension
+from markdown.treeprocessors import Treeprocessor
 from mdx_gh_links import GithubLinks
 
 
 # increment for any update that changes rendered output
-RENDER_CONFIG_VERSION = '0.1.1'
+RENDER_CONFIG_VERSION = '0.2.0'
 __version__ = f'{RENDER_CONFIG_VERSION}/markdown={markdown.__version__}'
 
-
-ok_tags = markdown_tags + ['div', 'pre']
-ok_attrs = defaultdict(list, **markdown_attrs)
-ok_attrs['div'].append('class')
-ok_attrs['span'].append('class')
+LINK_PREFIXES = ('www.', 'http://', 'https://', 'mailto:')
 
 
 base_extensions = (
     'codehilite',
     'fenced_code',
     'footnotes',
-    'mdx_linkify',
     'mdx_breakless_lists',
 )
 
+allowed_attrs = {
+    '*': ['id', 'class'],
+    'img': ['src', 'alt', 'title'],
+    'a': ['href', 'alt', 'title'],
+}
 
-def render_github(text, user, repo):
-    extras = (
-        GithubLinks(user=user, repo=repo),
-    )
+
+class GHImageProcessor(Treeprocessor):
+    GH_IMG_ROOT = 'https://raw.githubusercontent.com'
+
+    def __init__(self, config, md):
+        super().__init__(md)
+        self.config = config
+
+    def run(self, root):
+        user = self.config['user']
+        repo = self.config['repo']
+        sha = self.config['sha']
+        for el in root.iter('img'):
+            src = el.attrib['src']
+            if src.startswith('http://') or src.startswith('https://'):
+                continue  # leave absolute image urls alone
+            el.set('src', f'{self.GH_IMG_ROOT}/{user}/{repo}/{sha}/{src}')
+
+
+class GithubLinksAlsoImages(GithubLinks):
+    def __init__(self, *args, **kwargs):
+        self.config = {
+            'user': ['', 'GitHub user or organization.'],
+            'repo': ['', 'Repository name.'],
+            'sha': ['', 'Sha-1 hash of commit.'],
+        }
+        Extension.__init__(self, *args, **kwargs)
+
+    def extendMarkdown(self, md):
+        super().extendMarkdown(md)
+        md.treeprocessors.register(
+            GHImageProcessor(self.getConfigs(), md), 'gh_image', 20)
+
+
+def only_abs_link(attrs, new=False):
+    if new is False or \
+       any(attrs['_text'].startswith(p) for p in LINK_PREFIXES):
+        return attrs
+
+
+def render_github(text, user, repo, sha):
+    extras = (GithubLinksAlsoImages(user=user, repo=repo, sha=sha),)
     html = markdown.markdown(text, extensions=base_extensions + extras)
-    return bleach.clean(html, ok_tags, ok_attrs)
+    safe = bleach.clean(html, markdown_tags, allowed_attrs)
+    return bleach.linkify(safe, callbacks=[only_abs_link], skip_tags=['pre'])

--- a/requirements.thawed.txt
+++ b/requirements.thawed.txt
@@ -1,5 +1,5 @@
 bleach~=3.3.0
-bleach-whitelist~=0.0.11
+bleach-allowlist~=1.0.3
 dulwich~=0.20.15 --global-option="--pure"
 feedwerk==0.0.2
 flask~=1.1.2
@@ -10,8 +10,7 @@ Flask-WTF~=0.14.3
 gunicorn~=20.0.4
 markdown~=3.3.4
 mdx-breakless-lists~=1.0.1
-mdx-gh-links~=0.2
-mdx-linkify~=2.1
+-e git://github.com/uniphil/github-links.git@d6a74287d8bc3b5046cf96a9324a438337edcdae#egg=mdx_gh_links
 newrelic~=6.2.0.156
 pygments~=2.8.1
 pytest~=6.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 attrs==20.3.0
 bleach==3.3.0
-bleach-whitelist==0.0.11
+bleach-allowlist==1.0.3
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
-dulwich==0.20.20 --global-option="--pure"
+dulwich==0.20.21 --global-option="--pure"
 feedwerk==0.0.2
 Flask==1.1.2
 Flask-Login==0.5.0
@@ -20,20 +20,19 @@ Jinja2==2.11.3
 Markdown==3.3.4
 MarkupSafe==1.1.1
 mdx-breakless-lists==1.0.1
-mdx-gh-links==0.2
-mdx-linkify==2.1
+-e git://github.com/uniphil/github-links.git@d6a74287d8bc3b5046cf96a9324a438337edcdae#egg=mdx_gh_links
 newrelic==6.2.0.156
 packaging==20.9
 pluggy==0.13.1
 py==1.10.0
 Pygments==2.8.1
 pyparsing==2.4.7
-pytest==6.2.2
+pytest==6.2.3
 python-dateutil==2.8.1
 rauth==0.7.3
 requests==2.25.1
 six==1.15.0
-SQLAlchemy==1.3.23
+SQLAlchemy==1.4.5
 toml==0.10.2
 urllib3==1.26.4
 webencodings==0.5.1

--- a/tests/test_render_message.py
+++ b/tests/test_render_message.py
@@ -2,31 +2,31 @@ from render_message import render_github
 
 
 def test_render_github_basic():
-    out = render_github('hello', 'uniphil', 'commit--blog')
+    out = render_github('hello', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
     assert out == '<p>hello</p>'
 
 
 def test_render_github_allows_some_tags():
-    out = render_github('<ol><li>item one</li></ol>', 'uniphil', 'commit--blog')
+    out = render_github('<ol><li>item one</li></ol>', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
     assert out == '<ol><li>item one</li></ol>'
 
 
 def test_render_github_escapes_other_tags():
-    bodied = render_github('<body>breaks', 'uniphil', 'commit--blog')
+    bodied = render_github('<body>breaks', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
     assert bodied == '&lt;body&gt;breaks'
-    xss = render_github('<script>;alert(1)</script>', 'uniphil', 'gotcha')
+    xss = render_github('<script>;alert(1)</script>', 'uniphil', 'gotcha', '1337')
     assert xss == '&lt;script&gt;;alert(1)&lt;/script&gt;'
 
 
 def test_render_github_tags_people():
-    out = render_github('sup @rileyjshaw', 'uniphil', 'commit--blog')
-    expected = '<p>sup <a href="https://github.com/rileyjshaw" title="GitHub User: @rileyjshaw">@rileyjshaw</a></p>'
+    out = render_github('sup @rileyjshaw', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
+    expected = '<p>sup <a class="gh-link gh-mention" href="https://github.com/rileyjshaw" title="GitHub User: @rileyjshaw">@rileyjshaw</a></p>'
     assert out == expected
 
 
 def test_render_github_links_issues():
-    out = render_github('as seen in #123...', 'uniphil', 'commit--blog')
-    expected = '<p>as seen in <a href="https://github.com/uniphil/commit--blog/issues/123" title="GitHub Issue uniphil/commit--blog #123">#123</a>...</p>'
+    out = render_github('as seen in #123...', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
+    expected = '<p>as seen in <a class="gh-link gh-issue" href="https://github.com/uniphil/commit--blog/issues/123" title="GitHub Issue uniphil/commit--blog #123">#123</a>...</p>'
     assert out == expected
 
 
@@ -35,20 +35,22 @@ def test_render_fenced():
 ```
 code in fences
 ```
-''', 'uniphil', 'commit--blog')
+''', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
     assert '<code>' in out
     assert 'codehilite' in out
     hl = render_github('''\
 ```python
 # ...no comment
 ```
-''', 'uniphil', 'commit--blog')
+''', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
     assert 'class="c1"' in hl
 
+
 def test_regression_render_autolink():
-    out = render_github('for example: https://example.com.', 'uniphil', 'commit--blog')
+    out = render_github('for example: https://example.com.', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
     expected = '<p>for example: <a href="https://example.com">https://example.com</a>.</p>'
     assert out == expected
+
 
 def test_regression_render_lists():
     out = render_github('''\
@@ -56,7 +58,7 @@ ok:
 - here is a list but
 - i did not leave a blank line
 - hope it will not break
-''', 'uniphil', 'commit--blog')
+''', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
     expected = '''\
 <p>ok:</p>
 <ul>
@@ -64,4 +66,26 @@ ok:
 <li>i did not leave a blank line</li>
 <li>hope it will not break</li>
 </ul>'''
+    assert out == expected
+
+
+def test_regression_render_gh_image():
+    out = render_github('''\
+POC: ![i am an image](static/img/dash-b.png)
+''', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
+    expected = '''\
+<p>POC: <img alt="i am an image" src="https://raw.githubusercontent.com/uniphil/commit--blog/b7caf89bfd8f67e459e8e86e684553f99533c495/static/img/dash-b.png"></p>'''
+    assert out == expected
+
+    out_abs = render_github('''\
+![but abs urls don't change](https://example.com/an-image.png)
+''', 'uniphil', 'commit--blog', 'b7caf89bfd8f67e459e8e86e684553f99533c495')
+    expected_abs = '''\
+<p><img alt="but abs urls don't change" src="https://example.com/an-image.png"></p>'''
+    assert out_abs == expected_abs
+
+
+def test_regression_only_proto_links():
+    out = render_github('readme.md', 'uniphil', 'commit--blog', 'asdf')
+    expected = '<p>readme.md</p>'
     assert out == expected


### PR DESCRIPTION
1. Allow `class` on any tag. I'd really like to be able to trust attributes added by `python-markdown` & extensions, but not trust attributes set on html by commit authors, but there's not a particularly easy way to do this with python-markdown and bleach. It might be possible to break the layout by using some commit--blog site classes in a commit message, but I think the impact is small enough not to worry for now. The only place it can break is the author's own blog.

2. Use bleach.linkify instead of the mdx_* plugin. Hopefully avoiding a lot of the general mess with markdown links, and saving a dependency.

3. Replace broken regex hack for github images with a little python-markdown extension. The commit-ish is needed for generating raw.githubusercontent urls, so that's now an additional required piece of context when rendering markdown.

I'd sort of like to run bleach on the input _before_ running it through `python-markdown`, but that runs into problems with both markdown syntax getting mangled, and double-escaping like `&amp;lt;` in some places (which I think are arguably bugs in the model of python-markdown, but, 🤷🏼 ).

For 1., I think the biggest threat to allowing user-submitted `class`es is some kind of phishing attack, where the site's own styles could be used to fool a visitor into clicking a site-looking link that leads to an attacker-controlled page. For the time being, I'm going to hold off on trying to mitigate that, since it feels like a very high-effort low-value target (and honestly would be really cool if someone pulled it off). I don't think it will be hard to mitigate, but might be annoying with site style changes depending on the approach.