### PR TITLE
don't linkify in `code` bits

### DIFF
--- a/render_message.py
+++ b/render_message.py
@@ -9,7 +9,7 @@ from mdx_gh_links import GithubLinks
 
 
 # increment for any update that changes rendered output
-RENDER_CONFIG_VERSION = '0.2.0'
+RENDER_CONFIG_VERSION = '0.2.1'
 __version__ = f'{RENDER_CONFIG_VERSION}/markdown={markdown.__version__}'
 
 LINK_PREFIXES = ('www.', 'http://', 'https://', 'mailto:')
@@ -72,4 +72,4 @@ def render_github(text, user, repo, sha):
     extras = (GithubLinksAlsoImages(user=user, repo=repo, sha=sha),)
     html = markdown.markdown(text, extensions=base_extensions + extras)
     safe = bleach.clean(html, markdown_tags, allowed_attrs)
-    return bleach.linkify(safe, callbacks=[only_abs_link], skip_tags=['pre'])
+    return bleach.linkify(safe, callbacks=[only_abs_link], skip_tags=['code'])

--- a/tests/test_render_message.py
+++ b/tests/test_render_message.py
@@ -89,3 +89,9 @@ def test_regression_only_proto_links():
     out = render_github('readme.md', 'uniphil', 'commit--blog', 'asdf')
     expected = '<p>readme.md</p>'
     assert out == expected
+
+
+def test_regression_no_linkify_in_code():
+    out = render_github('`https://example.com`', 'uniphil', 'commit--blog', 'asdf')
+    expected = '<p><code>https://example.com</code></p>'
+    assert out == expected


### PR DESCRIPTION
a tiny linkifier regression

`pre` is switched for `code` for places not to linkify, which should be ok since the `codehilite` plugin always wraps code in `<code>` even inside the `<pre>`. The only place I think this would be a problem is if someone used a `<pre>` tag literally in their message and expected not to have it linkified.

🤷🏻 getting linkified isn't a huge deal hopefully, and it's easy to add `pre` back if someone needs it.