### PR TITLE
Fix codehilite output: no guessing

### DIFF
--- a/render_message.py
+++ b/render_message.py
@@ -3,20 +3,20 @@ import markdown
 from bleach_allowlist import markdown_tags
 from collections import defaultdict
 from functools import partial
-from markdown.extensions import Extension
+from markdown.extensions import Extension, codehilite
 from markdown.treeprocessors import Treeprocessor
 from mdx_gh_links import GithubLinks
 
 
 # increment for any update that changes rendered output
-RENDER_CONFIG_VERSION = '0.2.1'
+RENDER_CONFIG_VERSION = '0.2.2'
 __version__ = f'{RENDER_CONFIG_VERSION}/markdown={markdown.__version__}'
 
 LINK_PREFIXES = ('www.', 'http://', 'https://', 'mailto:')
 
 
 base_extensions = (
-    'codehilite',
+    codehilite.CodeHiliteExtension(guess_lang=False),
     'fenced_code',
     'footnotes',
     'mdx_breakless_lists',

--- a/tests/test_render_message.py
+++ b/tests/test_render_message.py
@@ -95,3 +95,13 @@ def test_regression_no_linkify_in_code():
     out = render_github('`https://example.com`', 'uniphil', 'commit--blog', 'asdf')
     expected = '<p><code>https://example.com</code></p>'
     assert out == expected
+
+
+def test_regression_no_guessing():
+    out = render_github('''\
+```
+const ANSWER = 42;
+```
+''', 'uniphil', 'commit--blog', 'asdf')
+    expected = '<div class="codehilite"><pre><span></span><code>const ANSWER = 42;\n</code></pre></div>'
+    assert out == expected


### PR DESCRIPTION
If a language is not specified, do not try to guess.

Fixes #49 

before:

<img width="723" alt="Screen Shot 2021-04-04 at 19 46 23" src="https://user-images.githubusercontent.com/205128/113525111-19235d80-9581-11eb-9393-4d70a76d2e20.png">

after:

<img width="602" alt="Screen Shot 2021-04-04 at 20 04 23" src="https://user-images.githubusercontent.com/205128/113525119-22acc580-9581-11eb-9a66-dc5fb306cba8.png">
