### PR TITLE
System cryptography

### DIFF
--- a/freeze.sh
+++ b/freeze.sh
@@ -37,6 +37,10 @@ venv.freezing/bin/pip --disable-pip-version-check install -qr requirements.thawe
 msg Freeze packages in venv.freezing to requirements.freezing.txt
 venv.freezing/bin/pip freeze > requirements.freezing.txt
 
+msg Clean system packages from requirements.freezing.txt
+sed -e '/^\s*$/d' -e '/^#/d' requirements.system.txt \
+    | while read dep; do sed -e "/^$dep/d" -i '' requirements.freezing.txt; done
+
 msg Clean up venv.freezing
 rm -fr venv.freezing/
 

--- a/requirements.system.txt
+++ b/requirements.system.txt
@@ -1,0 +1,2 @@
+# fails to build on openbsd (both newer rustc and older c/openssl). use python3-cryptography via pkg_add.
+cryptography

--- a/requirements.thawed.txt
+++ b/requirements.thawed.txt
@@ -1,6 +1,7 @@
 Authlib~=0.15.5
 bleach~=3.3.0
 bleach-allowlist~=1.0.3
+cryptography==3.3.2
 email_validator~=1.1.3
 feedwerk~=1.0.0
 flask~=1.1.2

--- a/requirements.thawed.txt
+++ b/requirements.thawed.txt
@@ -1,7 +1,6 @@
 Authlib~=0.15.5
 bleach~=3.3.0
 bleach-allowlist~=1.0.3
-cryptography==3.3.2
 email_validator~=1.1.3
 feedwerk~=1.0.0
 flask~=1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.9
 click==7.1.2
-# cryptography==3.3.2  -- installed via openbsd system package (pip build fails)
 dnspython==2.1.0
 email-validator==1.1.3
 feedwerk==1.0.0
@@ -21,7 +20,7 @@ gevent==21.1.2
 greenlet==1.1.2
 gunicorn==20.1.0
 idna==3.3
-importlib-metadata==4.8.2
+importlib-metadata==4.10.0
 iniconfig==1.1.1
 itsdangerous==1.1.0
 Jinja2==2.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.9
 click==7.1.2
-cryptography==3.3.2
+# cryptography==3.3.2  -- installed via openbsd system package (pip build fails)
 dnspython==2.1.0
 email-validator==1.1.3
 feedwerk==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.9
 click==7.1.2
-cryptography==36.0.0
+cryptography==3.3.2
 dnspython==2.1.0
 email-validator==1.1.3
 feedwerk==1.0.0


### PR DESCRIPTION
can't install this via pypi on openbsd -- new versions fail to build because rust; old versions fail to build because openssl. but! there is a system version we can `pkg_add`, which is compatible with `authlib` (who requires it).

so this works, but the `freeze` script will need to be updated to not clobber it.